### PR TITLE
[debug] fix fuzzy import issue for operators

### DIFF
--- a/dataflow/io/__init__.py
+++ b/dataflow/io/__init__.py
@@ -11,4 +11,4 @@ else:
     cur_path = "dataflow/io/"
 
     _import_structure = generate_import_structure_from_type_checking(__file__, cur_path)
-    sys.modules[__name__] = LazyLoader(__name__, "dataflow/io/", _import_structure)
+    sys.modules[__name__] = LazyLoader(__name__, "dataflow/io/", _import_structure, if_fuzzy_key_matching=True)

--- a/dataflow/utils/registry.py
+++ b/dataflow/utils/registry.py
@@ -209,7 +209,7 @@ OPERATOR_REGISTRY = Registry(name='operators', sub_modules=['core_vision', 'conv
 IO_REGISTRY = Registry(name='io')
 class LazyLoader(types.ModuleType):
 
-    def __init__(self, name, path, import_structure):
+    def __init__(self, name, path, import_structure, if_fuzzy_key_matching=False):
         """
         初始化 LazyLoader 模块。
 
@@ -218,6 +218,7 @@ class LazyLoader(types.ModuleType):
         """
         super().__init__(name)
         self._import_structure = import_structure
+        self.if_fuzzy_key_matching = if_fuzzy_key_matching
         self._loaded_classes = {}
         self._base_folder = Path(__file__).resolve().parents[2]
         self.__path__ = [path]
@@ -322,7 +323,7 @@ class LazyLoader(types.ModuleType):
             logger.debug(f"Lazyloader {self.__path__} got and cached class {cls}")
             self._loaded_classes[item] = cls
             return cls
-        else:
+        elif self.if_fuzzy_key_matching:
             # 如果没有在Import Structure里面，进行字符串匹配
             logger.info(f"No matched class in LazyLoader {self.__path__} for {item}, start string matching!!!")
             normalized_cls_name = self._normalize(item)

--- a/test/test_promptedvqa.py
+++ b/test/test_promptedvqa.py
@@ -17,7 +17,7 @@ class VQAGenerator():
             # hf_model_name_or_path="/data0/models/Qwen2.5-VL-7B-Instruct",
             hf_model_name_or_path="/mnt/public/model/huggingface/Qwen2.5-VL-3B-Instruct",
             hf_cache_dir=self.model_cache_dir,
-            vllm_tensor_parallel_size=2,
+            vllm_tensor_parallel_size=1,
             vllm_temperature=0.7,
             vllm_top_p=0.9, 
             vllm_max_tokens=512,


### PR DESCRIPTION
When attempting to import an operator such as `PromptVQA`(does not exist in our library), the issue arises because the exact match is `PromptedVQAGenerator`. The lazy loader performs fuzzy matching and imports this operator, which is not the intended behavior.